### PR TITLE
Add the ability to filter on file extensions for browserify

### DIFF
--- a/browserify.js
+++ b/browserify.js
@@ -8,7 +8,28 @@
 'use strict';
 
 var webkitAssign = require('./index');
+var through2 = require('through2');
+var _ = require('lodash');
 
-module.exports = function () {
-    return webkitAssign();
+var defaultOptions = {
+    extension: ['.js']
+};
+
+module.exports = function (file, options) {
+    // Merge options with default options
+    _.defaults(options, defaultOptions);
+    // Turn single extention option from CLI into array
+    if (!_.isArray(options.extension)) {
+        options.extension = [options.extension];
+    }
+    // Check if it matches accepting extention
+    var match = _.any(options.extension, function (opt) {
+        return _.endsWith(file, opt);
+    });
+
+    if (match) {
+        return webkitAssign();
+    } else {
+        return through2();
+    }
 };

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "through2": "^2.0.0"
   },
   "devDependencies": {
+    "browserify-transform-tools": "^1.5.0",
     "jscs": "^2.1.1",
     "jshint": "^2.8.0",
     "mocha": "^2.2.5"

--- a/test/test.js
+++ b/test/test.js
@@ -1,10 +1,12 @@
 'use strict';
 
 var assert = require('assert');
+var browserify = require('../browserify');
 var fs = require('graceful-fs');
 var gulpPlugin = require('../gulp');
 var gutil = require('gulp-util');
 var path = require('path');
+var transformTools = require('browserify-transform-tools');
 var webkitAssign = require('../index');
 
 var getFileContents = function (file) {
@@ -76,5 +78,39 @@ describe('gulp', function () {
             contents: new Buffer(getFileContents(fixture))
         }));
         stream.end();
+    });
+});
+
+describe('browserify', function () {
+    var input = './test/fixtures/replace.input.js';
+    var expected = './test/fixtures/replace.expected.js';
+    var options = {
+        config: {}
+    };
+    it('should work as a browserify transform', function (done) {
+        transformTools.runTransform(browserify, input, options, function (err, result) {
+            if (err) {
+                return done(err);
+            }
+
+            assert.strictEqual(result, getFileContents(expected));
+            done();
+        });
+    });
+
+    it('should filter based on extension', function (done) {
+        var options = {
+            config: {
+                extension: []
+            }
+        };
+        transformTools.runTransform(browserify, input, options, function (err, result) {
+            if (err) {
+                return done(err);
+            }
+
+            assert.strictEqual(result, getFileContents(input));
+            done();
+        });
     });
 });


### PR DESCRIPTION
In our case, we also include .json files which are a problem to parse by recast. In addition, there was a small problem with the nodes from the AST, sometimes being null. I added a check for that.

It might be even better to migrate the filtering to the main module, but this would require a bit more restructuring and testing. I don't know if you are open to these changes? If so, just let me know!
