### PR TITLE
Fix parsing for null nodes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,18 +34,16 @@ var getOutputFile = function (file) {
  * children.
  */
 var traverse = function traverse(node, iteratee) {
-    iteratee(node);
-    _.forOwn(node, function (child) {
-        if (_.isObject(child)) {
-            if (_.isArray(child)) {
-                _.forEach(child, function (node) {
-                    traverse(node, iteratee);
-                });
-            } else {
-                traverse(child, iteratee);
-            }
-        }
-    });
+    if (_.isArray(node)) {
+        _.forEach(node, function (child) {
+            traverse(child, iteratee);
+        });
+    } else if (_.isObject(node)) {
+        iteratee(node);
+        _.forOwn(node, function (child) {
+            traverse(child, iteratee);
+        });
+    }
 };
 
 var getNumberOfLines = function (string) {

--- a/test/test.js
+++ b/test/test.js
@@ -28,6 +28,14 @@ var inputOutputTest = function (prefix, done) {
     });
 };
 
+describe('parse', function () {
+    it('should not fail on null nodes', function () {
+        assert.doesNotThrow(function () {
+            webkitAssign('[,0]');
+        });
+    });
+});
+
 describe('replace', function () {
     it('should replace properties with variables', function (done) {
         inputOutputTest('replace', done);


### PR DESCRIPTION
Fixes #7.

It was failing to parse on [an empty array index](https://github.com/ftlabs/fastclick/blob/43fe1b576176231e2277c3ad8f28c94c7d278175/lib/fastclick.js#L746).
