### PR TITLE
Protect against unary increment and decrement operators.

### DIFF
--- a/test/fixtures/increment-decrement.expected.js
+++ b/test/fixtures/increment-decrement.expected.js
@@ -1,0 +1,8 @@
+var __webkitAssign__a = "a";object[__webkitAssign__a]++;
+object[__webkitAssign__a]--;
+++object[__webkitAssign__a];
+--object[__webkitAssign__a];
+a++;
+a--;
+++a;
+--a;

--- a/test/fixtures/increment-decrement.input.js
+++ b/test/fixtures/increment-decrement.input.js
@@ -1,0 +1,8 @@
+object.a++;
+object.a--;
+++object.a;
+--object.a;
+a++;
+a--;
+++a;
+--a;

--- a/test/test.js
+++ b/test/test.js
@@ -42,6 +42,9 @@ describe('replace', function () {
     it('should replace properties with variables', function (done) {
         inputOutputTest('replace', done);
     });
+    it('should protect against increment / decrement operators', function (done) {
+        inputOutputTest('increment-decrement', done);
+    });
     it('should preserve directive placement', function (done) {
         inputOutputTest('directive', done);
     });


### PR DESCRIPTION
WebKit probably treats unary increment and decrement operators (`++` and `--`) like assignment operators, as the following code throws a `TypeError` on Safari:

``` js
(function () {
    'use strict';
    var o = Object.create(null, {a: {value: 0}});
    o.a++;
}());
```

Therefore, the following code should be transformed:

``` js
object.a++;
```

Into this:

``` js
var __webkitAssign__a = "a";
object[__webkitAssign__a]++;
```
